### PR TITLE
Fix regex pattern

### DIFF
--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -815,7 +815,7 @@ class Normalizer
         $at = null;
         $shortAddress = null;
 
-        if (preg_match('/(?<zipcode>(^\d{5}|^\d{3})?)(?<county>\D{2}[縣市])?(?<district>\D+[鄉鎮市區])?(?<town>\D+[村里])?(?<lin>.+[鄰])?(?<road>\D+[路街大道])?(?<sec>.+[段])?(?<len>.+[巷])?(?<non>.+[弄])?(?<no>.+[號])?(?<floor>.+[樓Ff])?(?<at>[之-].+)?/u', $address, $matches) !== 0) {
+        if (preg_match('/(?<zipcode>(^\d{5}|^\d{3})?)(?<county>\D{2}[縣市])?(?<district>(\D+[^鄉鎮市區](鄉|鎮|市|區)|\D+(鄉|鎮|市|區)))?(?<town>\D+[村里])?(?<lin>.+[鄰])?(?<road>\D+[路街大道])?(?<sec>.+[段])?(?<len>.+[巷])?(?<non>.+[弄])?(?<no>.+[號])?(?<floor>.+[樓Ff])?(?<at>[之-].+)?/u', $address, $matches) !== 0) {
             $zipcode = $this->arrayGet($matches, 'zipcode');
             $county = $this->arrayGet($matches, 'county');
             $district = $this->arrayGet($matches, 'district');

--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -815,7 +815,7 @@ class Normalizer
         $at = null;
         $shortAddress = null;
 
-        if (preg_match('/(?<zipcode>(^\d{5}|^\d{3})?)(?<county>\D{2}[縣市])?(?<district>(\D+[^鄉鎮市區](鄉|鎮|市|區)|\D+(鄉|鎮|市|區)))?(?<town>\D+[村里])?(?<lin>.+[鄰])?(?<road>\D+[路街大道])?(?<sec>.+[段])?(?<len>.+[巷])?(?<non>.+[弄])?(?<no>.+[號])?(?<floor>.+[樓Ff])?(?<at>[之-].+)?/u', $address, $matches) !== 0) {
+        if (preg_match('/(?<zipcode>(^\d{5}|^\d{3})?)(?<county>\D{2}[縣市])?(?<district>(\D{1,3}[^鄉鎮市區新](鄉|鎮|市|區)|\D{1,3}(鄉|鎮|市|區)))?(?<town>\D+[村里])?(?<lin>.+[鄰])?(?<road>\D+[路街大道])?(?<sec>.+[段])?(?<len>.+[巷])?(?<non>.+[弄])?(?<no>.+[號])?(?<floor>.+[樓Ff])?(?<at>[之-].+)?/u', $address, $matches) !== 0) {
             $zipcode = $this->arrayGet($matches, 'zipcode');
             $county = $this->arrayGet($matches, 'county');
             $district = $this->arrayGet($matches, 'district');

--- a/tests/NormalizerTest.php
+++ b/tests/NormalizerTest.php
@@ -64,7 +64,7 @@ class NormalizerTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function test_taipei_datong_district_civic_blvd()
+    public function test_normailize_taipei_datong_district_civic_blvd()
     {
         $normalizer = new Normalizer('台北市大同區市民大道一段209號5樓');
         $this->assertSame($normalizer->toArray(), [
@@ -82,7 +82,7 @@ class NormalizerTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function test_district_only_two_words()
+    public function test_normailize_district_only_two_words()
     {
         $normalizer = new Normalizer('新竹市東區西大路323號8樓');
         $this->assertSame($normalizer->toArray(), [
@@ -100,7 +100,7 @@ class NormalizerTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function test_kaohsiung_qianzhen()
+    public function test_normailize_kaohsiung_qianzhen()
     {
         $normalizer = new Normalizer('高雄市前鎮區中華五路789號');
         $this->assertSame($normalizer->toArray(), [
@@ -114,6 +114,24 @@ class NormalizerTest extends PHPUnit_Framework_TestCase
             'non'      => '',
             'no'       => '789號',
             'floor'    => null,
+            'at'       => null,
+        ]);
+    }
+
+    public function test_normailize_kinmen()
+    {
+        $normalizer = new Normalizer('金門縣金湖鎮新市里太湖路二段198號6樓');
+        $this->assertSame($normalizer->toArray(), [
+            'county'   => '金門縣',
+            'district' => '金湖鎮',
+            'town'     => '新市里',
+            'lin'      => '',
+            'road'     => '太湖路',
+            'sec'      => '二段',
+            'len'      => '',
+            'non'      => '',
+            'no'       => '198號',
+            'floor'    => '6樓',
             'at'       => null,
         ]);
     }

--- a/tests/NormalizerTest.php
+++ b/tests/NormalizerTest.php
@@ -63,4 +63,58 @@ class NormalizerTest extends PHPUnit_Framework_TestCase
             'at'       => null,
         ]);
     }
+
+    public function test_taipei_datong_district_civic_blvd()
+    {
+        $normalizer = new Normalizer('台北市大同區市民大道一段209號5樓');
+        $this->assertSame($normalizer->toArray(), [
+            'county'   => '臺北市',
+            'district' => '大同區',
+            'town'     => '',
+            'lin'      => '',
+            'road'     => '市民大道',
+            'sec'      => '一段',
+            'len'      => '',
+            'non'      => '',
+            'no'       => '209號',
+            'floor'    => '5樓',
+            'at'       => null,
+        ]);
+    }
+
+    public function test_district_only_two_words()
+    {
+        $normalizer = new Normalizer('新竹市東區西大路323號8樓');
+        $this->assertSame($normalizer->toArray(), [
+            'county'   => '新竹市',
+            'district' => '東區',
+            'town'     => '',
+            'lin'      => '',
+            'road'     => '西大路',
+            'sec'      => '',
+            'len'      => '',
+            'non'      => '',
+            'no'       => '323號',
+            'floor'    => '8樓',
+            'at'       => null,
+        ]);
+    }
+
+    public function test_kaohsiung_qianzhen()
+    {
+        $normalizer = new Normalizer('高雄市前鎮區中華五路789號');
+        $this->assertSame($normalizer->toArray(), [
+            'county'   => '高雄市',
+            'district' => '前鎮區',
+            'town'     => '',
+            'lin'      => '',
+            'road'     => '中華五路',
+            'sec'      => '',
+            'len'      => '',
+            'non'      => '',
+            'no'       => '789號',
+            'floor'    => null,
+            'at'       => null,
+        ]);
+    }
 }

--- a/tests/TwzipcodeTest.php
+++ b/tests/TwzipcodeTest.php
@@ -57,4 +57,20 @@ class TwzipcodeTest extends PHPUnit_Framework_TestCase
         $this->assertSame($twzipcode->getAddress(true), '臺東縣臺東市中正路１００號');
         $this->assertSame($twzipcode->getShortAddress(true), '中正路１００號');
     }
+
+    public function test_taipei_datong_district_civic_blvd()
+    {
+        $twzipcode = new Twzipcode('台北市大同區市民大道一段209號5樓');
+        $this->assertSame($twzipcode->getZipcode(), '103');
+        $this->assertSame($twzipcode->getCounty(), '臺北市');
+        $this->assertSame($twzipcode->getDistrict(), '大同區');
+        $this->assertSame($twzipcode->getAddress(), '臺北市大同區市民大道一段209號5樓');
+        $this->assertSame($twzipcode->getShortAddress(), '市民大道一段209號5樓');
+
+        $this->assertSame($twzipcode->getZipcode(true), '１０３');
+        $this->assertSame($twzipcode->getCounty(true), '臺北市');
+        $this->assertSame($twzipcode->getDistrict(true), '大同區');
+        $this->assertSame($twzipcode->getAddress(true), '臺北市大同區市民大道一段２０９號５樓');
+        $this->assertSame($twzipcode->getShortAddress(true), '市民大道一段２０９號５樓');
+    }
 }


### PR DESCRIPTION
測試地址: 台北市大同區市民大道一段209號5樓
市民大道與鄉鎮市區同時出現 造成解析錯誤

``` php
array(11) {
  'county' =>
  string(9) "臺北市"
  'district' =>
  string(12) "大同區市"
  'town' =>
  string(0) ""
  'lin' =>
  string(0) ""
  'road' =>
  string(9) "民大道"
  'sec' =>
  string(6) "一段"
  'len' =>
  string(0) ""
  'non' =>
  string(0) ""
  'no' =>
  string(6) "209號"
  'floor' =>
  string(4) "5樓"
  'at' =>
  NULL
}
```

Fix:

``` php
array(11) {
  'county' =>
  string(9) "臺北市"
  'district' =>
  string(9) "大同區"
  'town' =>
  string(0) ""
  'lin' =>
  string(0) ""
  'road' =>
  string(12) "市民大道"
  'sec' =>
  string(6) "一段"
  'len' =>
  string(0) ""
  'non' =>
  string(0) ""
  'no' =>
  string(6) "209號"
  'floor' =>
  string(4) "5樓"
  'at' =>
  NULL
}
```
